### PR TITLE
solve strange issues occurred in building golden image and invoking SequenceR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # docker build -t ubuntu1604py36
-FROM ubuntu:16.04
+# FROM ubuntu:16.04
+FROM pytorch/pytorch:latest
 
 RUN apt-get update
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ docker run -it sequencer
 
 And now all dependecies are installed (including defects4j).
 
+### existing image
+
+Right now we have one reliable third-party golden image available at [DockerHub](https://cloud.docker.com/repository/docker/ycaxgjd/sequencer), in case that you only plan to invoke SequenceR.
+
 ## Without docker
 
 ### Install dependencies
@@ -56,6 +60,10 @@ To rerun our experiment of SequenceR over [Defects4J](https://github.com/rjust/d
 SequenceR uses the OpenNMT library to set up program repair as a translation from buggy code to fixed code. Documentation on OpenNMT including parameter setup is at:
 
 http://opennmt.net/OpenNMT-py/
+
+## GitLFS
+
+We use GitLFS to sync model files, so please visit [GitLFS homepage](https://git-lfs.github.com) before following steps. Usually, after the installation, remember to run `git lfs install` before other git commands.
 
 ## Setup
 

--- a/src/sequencer-predict.sh
+++ b/src/sequencer-predict.sh
@@ -112,7 +112,13 @@ fi
 echo
 
 echo "Generating predictions"
-python3 $CURRENT_DIR/lib/OpenNMT-py/translate.py -model $ROOT_DIR/model/model.pt -src $CURRENT_DIR/tmp/${BUGGY_FILE_BASENAME}_abstract_tokenized_truncated.txt -output $CURRENT_DIR/tmp/predictions.txt -beam_size $BEAM_SIZE -n_best $BEAM_SIZE &>/dev/null
+python3 $CURRENT_DIR/lib/OpenNMT-py/translate.py -model $ROOT_DIR/model/model.pt -src $CURRENT_DIR/tmp/${BUGGY_FILE_BASENAME}_abstract_tokenized_truncated.txt -output $CURRENT_DIR/tmp/predictions.txt -beam_size $BEAM_SIZE -n_best $BEAM_SIZE #&>/dev/null
+retval=$?
+if [ $retval -ne 0 ]; then
+  echo "Error in generating predictions"
+  rm -rf $CURRENT_DIR/tmp
+  exit 1
+fi
 echo
 
 echo "Post process predictions"
@@ -131,6 +137,12 @@ echo
 
 echo "Generating patches"
 python3 $CURRENT_DIR/Patch_Preparation/generatePatches.py $BUGGY_FILE_PATH $BUGGY_LINE $CURRENT_DIR/tmp/predictions_JavaSource.txt $OUTPUT
+retval=$?
+if [ $retval -ne 0 ]; then
+  echo "Error in generating patches"
+  rm -rf $CURRENT_DIR/tmp
+  exit 1
+fi
 echo
 
 echo "Generating diffs"

--- a/src/setup_env.sh
+++ b/src/setup_env.sh
@@ -48,9 +48,12 @@ fi
 
 if [ ! -d $CURRENT_DIR/lib/OpenNMT-py ]; then
   echo "Cloning OpenNMT-py"
-  git clone https://github.com/chenzimin/OpenNMT-py.git $CURRENT_DIR/lib/OpenNMT-py
+  # git clone https://github.com/chenzimin/OpenNMT-py.git $CURRENT_DIR/lib/OpenNMT-py
+  git clone https://github.com/OpenNMT/OpenNMT-py.git $CURRENT_DIR/lib/OpenNMT-py
   echo "Installing requirements for OpenNMT-py"
-  pip3 install -r $CURRENT_DIR/lib/OpenNMT-py/requirements.txt
+  cd $CURRENT_DIR/lib/OpenNMT-py
+  pip install -r requirements.txt
+  python setup.py install --force
   echo
 fi
 

--- a/src/setup_env.sh
+++ b/src/setup_env.sh
@@ -48,8 +48,7 @@ fi
 
 if [ ! -d $CURRENT_DIR/lib/OpenNMT-py ]; then
   echo "Cloning OpenNMT-py"
-  # git clone https://github.com/chenzimin/OpenNMT-py.git $CURRENT_DIR/lib/OpenNMT-py
-  git clone https://github.com/OpenNMT/OpenNMT-py.git $CURRENT_DIR/lib/OpenNMT-py
+  git clone https://github.com/chenzimin/OpenNMT-py.git $CURRENT_DIR/lib/OpenNMT-py
   echo "Installing requirements for OpenNMT-py"
   cd $CURRENT_DIR/lib/OpenNMT-py
   pip install -r requirements.txt


### PR DESCRIPTION
build on __pytorch__ image instead of __ubuntu__ image
add the link of existing third-party SequenceR docker image
add necessary hints about installing GitLFS
add more output for executing `sequencer-predict.sh`
fix the steps of installing __`OpenNMT-py`__ in `setup_env.sh`
